### PR TITLE
Removed Radiance Dependency for OffsetOpening

### DIFF
--- a/EnergyPlus_Engine/EnergyPlus_Engine.csproj
+++ b/EnergyPlus_Engine/EnergyPlus_Engine.csproj
@@ -78,10 +78,6 @@
       <HintPath>..\..\BHoM\Build\Physical_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Radiance_Engine">
-      <HintPath>..\..\Radiance_Toolkit\Build\Radiance_Engine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Reflection_Engine, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>

--- a/EnergyPlus_Engine/Modify/OffsetOpening.cs
+++ b/EnergyPlus_Engine/Modify/OffsetOpening.cs
@@ -10,7 +10,6 @@ using BH.Engine.Geometry;
 using BHE = BH.oM.Environment.Elements;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
-using BH.Engine.Radiance;
 using BH.Engine.Environment;
 
 namespace BH.Engine.EnergyPlus
@@ -19,11 +18,10 @@ namespace BH.Engine.EnergyPlus
     {
         [Description ("Reduces the area of the opening(s) if the total area of the opening(s) is equal to the area of the panel itself. Returns an Environment Panel object.")]
         [Input ("panel", "An Environment Panel object")]
-        [Output("panel", "An Environment Panel object")]
+        [Output("panel", "An Environment Panel object TEST TEST")]
         public static BHE.Panel OffsetOpening(BHE.Panel panel)
         {
-            BHE.Panel energyPlusPanel = new BHE.Panel();            
-
+            BHE.Panel energyPlusPanel = new BHE.Panel();                        
             //Checking if there are openings            
             if (panel.Openings.Count == 0)
             {                
@@ -66,11 +64,11 @@ namespace BH.Engine.EnergyPlus
                     foreach (BH.oM.Geometry.PolyCurve openingPolyCurve in openingPolyCurves)
                     {                        
                         List<BH.oM.Geometry.Point> polyPoints = openingPolyCurve.IDiscontinuityPoints();
-                        BH.oM.Geometry.Polyline openingPolyLine = BH.Engine.Geometry.Create.Polyline(polyPoints);
-                        List<BH.oM.Geometry.Polyline> offsetPolyline = BH.Engine.Radiance.Compute.Offset(openingPolyLine, distance);
-                        List<BHE.Edge> edges = offsetPolyline.Select(x => BH.Engine.Environment.Create.Edge(x)).ToList();                      
+                        BH.oM.Geometry.Polyline openingPolyLine = BH.Engine.Geometry.Create.Polyline(polyPoints);                        
+                        Polyline offsetPolyline = Geometry.Modify.Offset(openingPolyLine, distance);
+                        List<BHE.Edge> edges = offsetPolyline.ToEdges().ToList();                      
                         BHE.Opening newOpening = BH.Engine.Environment.Create.Opening("name", edges);
-                        panel.Openings.Add(newOpening);                        
+                        panel.Openings.Add(newOpening);                                               
                     }
                     return panel;
                 }


### PR DESCRIPTION


<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/1314
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #36 

<!-- Add short description of what has been fixed -->
Offset Opening now uses the offset method in Geometry_Engine instead of the one in Radiance, allowing the dependency on Radiance to be removed.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->