### PR TITLE
Migrate idfFilePath

### DIFF
--- a/EnergyPlus_Adapter/AdapterActions/Push.cs
+++ b/EnergyPlus_Adapter/AdapterActions/Push.cs
@@ -8,6 +8,7 @@ using BH.oM.Base;
 using System.Reflection;
 
 using System.IO;
+using BH.Engine.Adapter;
 
 namespace BH.Adapter.EnergyPlus
 {
@@ -33,7 +34,7 @@ namespace BH.Adapter.EnergyPlus
                 success &= ICreate(list as dynamic);
             }
 
-            StreamWriter sw = new StreamWriter(IDFFilePath);
+            StreamWriter sw = new StreamWriter(FileSettings.GetFullFileName());
 
             foreach (string s in FileOutput)
                 sw.WriteLine(s);

--- a/EnergyPlus_Adapter/EnergyPlusAdapter.cs
+++ b/EnergyPlus_Adapter/EnergyPlusAdapter.cs
@@ -15,26 +15,33 @@ using BH.oM.EnergyPlus.Settings;
 using System.Reflection;
 
 using BH.oM.Adapter;
+using System.IO;
 
 namespace BH.Adapter.EnergyPlus
 {
     public partial class EnergyPlusAdapter : BHoMAdapter
     {
         [Description("Produces an EnergyPlus Adapter to allow interopability with IDF files and the BHoM")]
-        [Input("idfFilePath", "Path to an IDF File")]
+        [Input("fileSettings", "Input file settings to get the path to an IDF File")]
         [Input("settings", "Settings that define how the EnergyPlus IDF file should be generated")]
         [Output("adapter", "Adapter to an IDF File")]
-        public EnergyPlusAdapter(string idfFilePath, EnergyPlusSettings settings = null)
+        public EnergyPlusAdapter(BH.oM.Adapter.FileSettings fileSettings, EnergyPlusSettings settings = null)
         {
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
 
-            IDFFilePath = idfFilePath;
+            FileSettings = fileSettings;
             _settings = settings ?? new EnergyPlusSettings();
+
+            if(!Path.HasExtension(fileSettings.FileName) || Path.GetExtension(fileSettings.FileName) != ".idf")
+            {
+                BH.Engine.Reflection.Compute.RecordError("File Name must contain a file extension");
+                return;
+            }
 
             AdapterIdName = "EnergyPlus_Adapter";
         }
 
-        private string IDFFilePath { get; set; }
+        private FileSettings FileSettings { get; set; }
         private EnergyPlusSettings _settings;
         private List<string> FileOutput { get; set; }
     }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #65 

The idfFilePath input for the adapter has been replaced by the fileSettings method in the Adapter_oM to get file name and directory for the adapter.


### Test files
[Test script](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FIES%5FToolkit%2FIES%5FFileSettings)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->